### PR TITLE
Use BOT_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,20 @@ Pressing a button will reply with a short confirmation message.
    pip install -r requirements.txt
    ```
 
-2. Run the bot:
+2. Set your Telegram bot token. You can either export the `BOT_TOKEN` environment
+   variable or create a `.env` file in the project root containing:
+
+   ```
+   BOT_TOKEN=<your token>
+   ```
+
+3. Run the bot:
 
    ```bash
    python bot.py
    ```
 
-The bot token is already defined in `bot.py`. If you need to use a different token, edit the value of `TOKEN` inside that file.
+The bot will read the token from the environment. If `BOT_TOKEN` is missing an
+informative error will be raised.
 
 The bot uses polling to receive updates.

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,20 @@
 import logging
+import os
+from dotenv import load_dotenv
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, CallbackContext
 
-# Telegram bot token
-TOKEN = "7559799114:AAHN_BDe68ghKLZClhSfqXTWrm2RroTw4vQ"
+# Load environment variables from .env if present
+load_dotenv()
+
+# Telegram bot token from environment
+try:
+    TOKEN = os.environ["BOT_TOKEN"]
+except KeyError as exc:
+    raise RuntimeError(
+        "BOT_TOKEN environment variable is missing. "
+        "Set it or create a .env file with BOT_TOKEN=<your token>."
+    ) from exc
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python-telegram-bot==13.15
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- load environment variables with `python-dotenv`
- read bot token from `BOT_TOKEN` env var and fail with a clear error message if missing
- update setup instructions in the README for using the env var or a `.env` file
- add `python-dotenv` to requirements

## Testing
- `BOT_TOKEN=dummy python -m py_compile bot.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6847dedf1348832a993a55ca4a1b4d96